### PR TITLE
Enable project reactions on public pages

### DIFF
--- a/db.js
+++ b/db.js
@@ -100,6 +100,24 @@ async function init() {
     ALTER TABLE projects
       ALTER COLUMN slug SET NOT NULL;
   `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS project_likes (
+      project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (project_id, user_id)
+    );
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS project_favorites (
+      project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (project_id, user_id)
+    );
+  `);
 }
 
 init().catch(err => console.error('DB init error', err));

--- a/public/project-detail.html
+++ b/public/project-detail.html
@@ -180,6 +180,23 @@
       transform: translateY(-2px);
     }
 
+    .reaction-btn{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .reaction-btn.active{
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      color: #0b0b16;
+      border-color: transparent;
+      box-shadow: 0 12px 24px rgba(139,92,246,0.28);
+    }
+
+    .reaction-btn.active:hover{
+      box-shadow: 0 18px 30px rgba(139,92,246,0.36);
+    }
+
     button[disabled]{
       opacity: .6;
       cursor: not-allowed;
@@ -241,6 +258,8 @@
         <button class="secondary" id="back-btn">← Back to Projects</button>
         <button class="primary" id="play-btn">Play game</button>
         <button class="primary" id="copy-btn">Copy project</button>
+        <button class="secondary reaction-btn" id="like-btn" aria-pressed="false">❤ Like</button>
+        <button class="secondary reaction-btn" id="favorite-btn" aria-pressed="false">★ Favorite</button>
       </div>
       <div class="status" id="status"></div>
     </div>
@@ -260,8 +279,50 @@
     const playBtn = document.getElementById('play-btn');
     const copyBtn = document.getElementById('copy-btn');
     const backBtn = document.getElementById('back-btn');
+    const likeBtn = document.getElementById('like-btn');
+    const favoriteBtn = document.getElementById('favorite-btn');
 
     const projectId = window.location.pathname.split('/').filter(Boolean).pop();
+
+    let csrfToken = null;
+    let allowReactions = false;
+    let projectState = { likes: 0, favorites: 0, liked: false, favorited: false };
+
+    function showStatus(message, type = '') {
+      statusEl.textContent = message || '';
+      statusEl.className = type ? `status ${type}` : 'status';
+    }
+
+    async function fetchCsrf() {
+      if (csrfToken) return csrfToken;
+      const res = await fetch('/api/csrf-token', { credentials: 'include' });
+      const data = await res.json();
+      csrfToken = data.csrfToken;
+      return csrfToken;
+    }
+
+    async function ensureCsrf() {
+      if (!csrfToken) {
+        await fetchCsrf();
+      }
+      return csrfToken;
+    }
+
+    function setReactionButtonsDisabled(disabled) {
+      likeBtn.disabled = disabled;
+      favoriteBtn.disabled = disabled;
+    }
+
+    function updateReactions() {
+      likesEl.textContent = `❤ ${projectState.likes}`;
+      favoritesEl.textContent = `★ ${projectState.favorites}`;
+      likeBtn.classList.toggle('active', projectState.liked);
+      favoriteBtn.classList.toggle('active', projectState.favorited);
+      likeBtn.setAttribute('aria-pressed', projectState.liked ? 'true' : 'false');
+      favoriteBtn.setAttribute('aria-pressed', projectState.favorited ? 'true' : 'false');
+    }
+
+    setReactionButtonsDisabled(true);
 
     backBtn.addEventListener('click', () => {
       window.location.href = '/projects';
@@ -272,17 +333,21 @@
     });
 
     async function copyProject() {
-      statusEl.textContent = 'Copying project...';
-      statusEl.className = 'status';
+      if (copyBtn.disabled) return;
+      showStatus('Copying project...');
       copyBtn.disabled = true;
       try {
+        await ensureCsrf();
         const res = await fetch(`/api/public-projects/${projectId}/copy`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' }
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken
+          }
         });
         if (res.status === 401) {
-          statusEl.textContent = 'Please sign in to copy this project.';
-          statusEl.className = 'status error';
+          showStatus('Please sign in to copy this project.', 'error');
           copyBtn.disabled = false;
           setTimeout(() => { window.location.href = '/login'; }, 1200);
           return;
@@ -291,24 +356,72 @@
           throw new Error('Copy failed');
         }
         const data = await res.json();
-        statusEl.textContent = 'Project copied! Redirecting to the editor...';
-        statusEl.className = 'status success';
+        showStatus('Project copied! Redirecting to the editor...', 'success');
         setTimeout(() => {
           window.location.href = (data && data.redirect) ? data.redirect : '/editor';
         }, 800);
       } catch (err) {
-        statusEl.textContent = 'Something went wrong while copying. Please try again later.';
-        statusEl.className = 'status error';
+        showStatus('Something went wrong while copying. Please try again later.', 'error');
         copyBtn.disabled = false;
       }
     }
 
     copyBtn.addEventListener('click', copyProject);
 
+    async function toggleReaction(type, button) {
+      if (!allowReactions || button.disabled) return;
+      button.disabled = true;
+      try {
+        await ensureCsrf();
+        const res = await fetch(`/api/public-projects/${projectId}/${type}`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken
+          }
+        });
+        if (res.status === 401) {
+          showStatus('Please sign in to like or favorite projects.', 'error');
+          setTimeout(() => { window.location.href = '/login'; }, 1200);
+          return;
+        }
+        if (!res.ok) {
+          throw new Error('Failed reaction');
+        }
+        const data = await res.json();
+        if (data && data.project) {
+          projectState = {
+            likes: Number(data.project.likes) || 0,
+            favorites: Number(data.project.favorites) || 0,
+            liked: Boolean(data.project.liked),
+            favorited: Boolean(data.project.favorited)
+          };
+          updateReactions();
+          showStatus('');
+        }
+      } catch (err) {
+        showStatus('Could not update project reaction. Please try again later.', 'error');
+      } finally {
+        button.disabled = !allowReactions;
+      }
+    }
+
+    likeBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      toggleReaction('like', likeBtn);
+    });
+
+    favoriteBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      toggleReaction('favorite', favoriteBtn);
+    });
+
     async function loadProject() {
       try {
         const res = await fetch(`/api/public-projects/${projectId}`);
         if (res.status === 404) {
+          panel.hidden = true;
           notFound.hidden = false;
           return;
         }
@@ -317,22 +430,39 @@
         }
         const data = await res.json();
         const project = data.project;
+        projectState = {
+          likes: Number(project.likes) || 0,
+          favorites: Number(project.favorites) || 0,
+          liked: Boolean(project.liked),
+          favorited: Boolean(project.favorited)
+        };
         projectName.textContent = project.name;
         ownerEl.textContent = `👤 ${project.ownerName}`;
-        likesEl.textContent = `❤ ${project.likes}`;
-        favoritesEl.textContent = `★ ${project.favorites}`;
+        updateReactions();
         panel.hidden = false;
-        statusEl.textContent = '';
+        notFound.hidden = true;
+
         if (!data.authenticated) {
+          allowReactions = false;
           copyBtn.disabled = true;
-          statusEl.textContent = 'Sign in to copy this project to your workspace.';
-        }
-        if (data.isOwner) {
+          setReactionButtonsDisabled(true);
+          showStatus('Sign in to copy, like, or favorite this project.');
+        } else if (data.isOwner) {
+          allowReactions = false;
           copyBtn.disabled = true;
-          statusEl.textContent = 'This is your project. You can edit it directly in the editor.';
+          setReactionButtonsDisabled(true);
+          showStatus('This is your project. You can edit it directly in the editor.');
+        } else {
+          allowReactions = true;
+          copyBtn.disabled = false;
+          setReactionButtonsDisabled(false);
+          showStatus('');
+          fetchCsrf().catch(() => {});
         }
       } catch (err) {
+        panel.hidden = true;
         notFound.hidden = false;
+        showStatus('Could not load this project right now.', 'error');
       }
     }
 

--- a/public/projects.html
+++ b/public/projects.html
@@ -193,9 +193,60 @@
     .project-meta{
       display: flex;
       align-items: center;
-      gap: 14px;
+      justify-content: space-between;
+      gap: 12px;
       color: var(--muted);
       font-size: 14px;
+      flex-wrap: wrap;
+    }
+
+    .project-owner{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .reaction-buttons{
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .reaction-button{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border: 1px solid rgba(255,255,255,0.14);
+      border-radius: 999px;
+      background: rgba(255,255,255,0.08);
+      color: var(--text);
+      padding: 6px 12px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background var(--transition), transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+    }
+
+    .reaction-button .count{
+      font-variant-numeric: tabular-nums;
+    }
+
+    .reaction-button:hover{
+      transform: translateY(-2px);
+    }
+
+    .reaction-button.active{
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      color: #0b0b16;
+      border-color: transparent;
+      box-shadow: 0 12px 24px rgba(139,92,246,0.24);
+    }
+
+    .reaction-button[disabled]{
+      opacity: .6;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
     }
 
     .empty-state{
@@ -290,27 +341,16 @@
       debounce: null
     };
 
-    function renderProjects(container, items) {
-      container.innerHTML = '';
-      for (const project of items) {
-        const card = document.createElement('article');
-        card.className = 'project-card';
-        card.innerHTML = `
-          <div class="project-name">${escapeHtml(project.name)}</div>
-          <div class="project-meta">
-            <span>❤ ${project.likes}</span>
-            <span>★ ${project.favorites}</span>
-          </div>
-        `;
-        card.addEventListener('click', () => {
-          window.location.href = `/projects/${project.id}`;
-        });
-        container.appendChild(card);
-      }
-    }
+    const projectState = new Map();
+    const appState = {
+      authenticated: false,
+      currentUserId: null
+    };
+    let csrfToken = null;
+    let errorTimer = null;
 
     function escapeHtml(text) {
-      return text.replace(/[&<>"']/g, c => ({
+      return String(text || '').replace(/[&<>"']/g, c => ({
         '&': '&amp;',
         '<': '&lt;',
         '>': '&gt;',
@@ -319,10 +359,206 @@
       })[c] || c);
     }
 
+    function showError(message, temporary = false) {
+      if (errorTimer) {
+        clearTimeout(errorTimer);
+        errorTimer = null;
+      }
+      errorBox.textContent = message;
+      errorBox.style.display = 'block';
+      if (temporary) {
+        errorTimer = setTimeout(() => {
+          errorBox.style.display = 'none';
+        }, 3000);
+      }
+    }
+
+    function hideError() {
+      if (errorTimer) clearTimeout(errorTimer);
+      errorTimer = null;
+      errorBox.style.display = 'none';
+      errorBox.textContent = '';
+    }
+
+    async function fetchCsrf() {
+      if (csrfToken) return csrfToken;
+      const res = await fetch('/api/csrf-token', { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to fetch CSRF token');
+      const data = await res.json();
+      csrfToken = data.csrfToken;
+      return csrfToken;
+    }
+
+    async function ensureCsrf() {
+      if (!csrfToken) {
+        await fetchCsrf();
+      }
+      return csrfToken;
+    }
+
+    function ensureProjectRecord(project) {
+      const existing = projectState.get(project.id) || {};
+      const ownerId = project.ownerId ?? existing.ownerId ?? null;
+      let ownerName = project.ownerName ?? existing.ownerName;
+      if (!ownerName) {
+        if (ownerId && appState.currentUserId && Number(ownerId) === Number(appState.currentUserId)) {
+          ownerName = 'You';
+        } else if (ownerId) {
+          ownerName = `Player ${ownerId}`;
+        } else {
+          ownerName = 'Player';
+        }
+      }
+      const record = {
+        id: project.id,
+        name: project.name || existing.name || 'Untitled Project',
+        ownerId,
+        ownerName,
+        likes: Number(project.likes ?? existing.likes ?? 0),
+        favorites: Number(project.favorites ?? existing.favorites ?? 0),
+        liked: Boolean(project.liked ?? existing.liked ?? false),
+        favorited: Boolean(project.favorited ?? existing.favorited ?? false)
+      };
+      projectState.set(project.id, record);
+      return record;
+    }
+
+    function updateProjectCard(card, record) {
+      const nameEl = card.querySelector('.project-name');
+      const ownerEl = card.querySelector('.project-owner');
+      const likeBtn = card.querySelector('.reaction-button[data-action="like"]');
+      const likeCount = likeBtn.querySelector('.count');
+      const favoriteBtn = card.querySelector('.reaction-button[data-action="favorite"]');
+      const favoriteCount = favoriteBtn.querySelector('.count');
+
+      nameEl.textContent = record.name;
+      ownerEl.textContent = `👤 ${record.ownerName}`;
+
+      likeBtn.classList.toggle('active', record.liked);
+      likeBtn.setAttribute('aria-pressed', record.liked ? 'true' : 'false');
+      likeCount.textContent = record.likes;
+
+      favoriteBtn.classList.toggle('active', record.favorited);
+      favoriteBtn.setAttribute('aria-pressed', record.favorited ? 'true' : 'false');
+      favoriteCount.textContent = record.favorites;
+
+      if (!appState.authenticated) {
+        likeBtn.disabled = true;
+        favoriteBtn.disabled = true;
+      } else {
+        likeBtn.disabled = false;
+        favoriteBtn.disabled = false;
+      }
+    }
+
+    function updateProjectDisplays(projectId) {
+      const record = projectState.get(projectId);
+      if (!record) return;
+      const cards = document.querySelectorAll(`.project-card[data-project-id="${projectId}"]`);
+      cards.forEach(card => updateProjectCard(card, record));
+    }
+
+    async function toggleReaction(projectId, type, button) {
+      if (!appState.authenticated) {
+        showError('Sign in to like or favorite projects.', true);
+        return;
+      }
+
+      button.disabled = true;
+      try {
+        await ensureCsrf();
+        const res = await fetch(`/api/public-projects/${projectId}/${type}`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken
+          }
+        });
+        if (res.status === 401) {
+          showError('Sign in to like or favorite projects.', true);
+          button.disabled = false;
+          return;
+        }
+        if (!res.ok) {
+          throw new Error('Failed reaction');
+        }
+        const data = await res.json();
+        if (data && data.project) {
+          const existing = projectState.get(projectId) || {};
+          const record = {
+            ...existing,
+            likes: Number(data.project.likes) || 0,
+            favorites: Number(data.project.favorites) || 0,
+            liked: Boolean(data.project.liked),
+            favorited: Boolean(data.project.favorited)
+          };
+          projectState.set(projectId, record);
+          updateProjectDisplays(projectId);
+          hideError();
+        }
+      } catch (err) {
+        showError('Unable to update project reaction. Please try again later.', true);
+      } finally {
+        if (appState.authenticated) {
+          button.disabled = false;
+        }
+      }
+    }
+
+    function createProjectCard(record) {
+      const card = document.createElement('article');
+      card.className = 'project-card';
+      card.dataset.projectId = record.id;
+      const disabledAttr = appState.authenticated ? '' : 'disabled';
+      card.innerHTML = `
+        <div class="project-name">${escapeHtml(record.name)}</div>
+        <div class="project-meta">
+          <span class="project-owner">👤 ${escapeHtml(record.ownerName)}</span>
+          <div class="reaction-buttons">
+            <button type="button" class="reaction-button${record.liked ? ' active' : ''}" data-action="like" aria-pressed="${record.liked}" ${disabledAttr}>
+              ❤ <span class="count">${record.likes}</span>
+            </button>
+            <button type="button" class="reaction-button${record.favorited ? ' active' : ''}" data-action="favorite" aria-pressed="${record.favorited}" ${disabledAttr}>
+              ★ <span class="count">${record.favorites}</span>
+            </button>
+          </div>
+        </div>
+      `;
+
+      card.addEventListener('click', () => {
+        window.location.href = `/projects/${record.id}`;
+      });
+
+      const likeBtn = card.querySelector('[data-action="like"]');
+      const favoriteBtn = card.querySelector('[data-action="favorite"]');
+
+      likeBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggleReaction(record.id, 'like', likeBtn);
+      });
+
+      favoriteBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggleReaction(record.id, 'favorite', favoriteBtn);
+      });
+
+      updateProjectCard(card, record);
+      return card;
+    }
+
+    function renderProjects(container, items) {
+      container.innerHTML = '';
+      for (const project of items) {
+        const record = ensureProjectRecord(project);
+        container.appendChild(createProjectCard(record));
+      }
+    }
+
     async function fetchProjects() {
       if (state.pending) return;
       state.pending = true;
-      errorBox.style.display = 'none';
+      hideError();
 
       const params = new URLSearchParams();
       if (state.search) params.set('search', state.search);
@@ -340,19 +576,28 @@
           state.filter = data.filter;
         }
 
-        if (!data.authenticated) {
+        appState.authenticated = !!data.authenticated;
+        appState.currentUserId = data.currentUserId;
+        if (!appState.authenticated) {
+          csrfToken = null;
+        } else {
+          fetchCsrf().catch(() => {});
+        }
+
+        if (!appState.authenticated) {
           userSection.style.display = '';
           userProjectsGrid.innerHTML = '';
           userEmpty.textContent = 'Sign in to see your public projects.';
           userEmpty.hidden = false;
-          userInfo.textContent = 'Sign in to explore and share your own public projects.';
+          userInfo.textContent = 'Sign in to explore, like, favorite, and share your own public projects.';
         } else {
           userSection.style.display = '';
           userInfo.textContent = 'These are the projects you have shared publicly.';
           userEmpty.textContent = 'No public projects yet. Toggle a project to public from the editor to showcase it here.';
           if (data.userProjects && data.userProjects.length) {
             userEmpty.hidden = true;
-            renderProjects(userProjectsGrid, data.userProjects);
+            const userItems = data.userProjects.map(p => ({ ...p, ownerName: 'You' }));
+            renderProjects(userProjectsGrid, userItems);
           } else {
             userProjectsGrid.innerHTML = '';
             userEmpty.hidden = false;
@@ -367,8 +612,7 @@
           projectsEmpty.hidden = false;
         }
       } catch (err) {
-        errorBox.textContent = 'Could not load projects right now. Please try again later.';
-        errorBox.style.display = 'block';
+        showError('Could not load projects right now. Please try again later.');
       } finally {
         state.pending = false;
       }

--- a/server.js
+++ b/server.js
@@ -246,7 +246,33 @@ function sendPublicProjectFile(res, ownerId, slug, projectNumericId, relPath) {
     if (!fs.existsSync(base)) return res.status(404).end();
     const full = path.resolve(base, normalized);
     if (full !== base && !full.startsWith(base + path.sep)) throw new Error('bad path');
-    if (!fs.existsSync(full)) return res.status(404).end();
+    if (!fs.existsSync(full)) {
+      if (normalized === 'index.html') {
+        return res
+          .status(200)
+          .type('text/html')
+          .send(`<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Missing index.html</title>
+    <style>
+      body{margin:0;font-family:system-ui,Segoe UI,sans-serif;background:#080512;color:#EEE9FF;display:flex;align-items:center;justify-content:center;height:100vh;text-align:center;padding:24px;}
+      main{max-width:540px;background:rgba(28,19,50,0.85);border:1px solid rgba(255,255,255,0.12);border-radius:18px;box-shadow:0 18px 40px rgba(0,0,0,0.45);padding:32px;}
+      h1{font-weight:600;margin-bottom:12px;}
+      p{color:#B6B0D4;line-height:1.6;}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Missing start file</h1>
+      <p>This public project does not have an <code>index.html</code> file or it is not accessible. Ask the creator to add one so the project can be played from here.</p>
+    </main>
+  </body>
+</html>`);
+      }
+      return res.status(404).end();
+    }
 
     const ctype = mime.lookup(full) || 'application/octet-stream';
     res.setHeader('Content-Type', ctype);
@@ -263,6 +289,92 @@ function sendPublicProjectFile(res, ownerId, slug, projectNumericId, relPath) {
     return res.sendFile(full);
   } catch (err) {
     return res.status(400).end();
+  }
+}
+
+async function handleProjectReaction(req, res, tableName, countColumn) {
+  const projectId = Number.parseInt(req.params.projectId, 10);
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    return res.status(400).json({ error: 'Invalid project id' });
+  }
+
+  const currentUserId = req.session?.userId || (req.user && req.user.id);
+  if (!currentUserId) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: projectRows } = await client.query(
+      'SELECT visibility FROM projects WHERE id=$1 FOR UPDATE',
+      [projectId]
+    );
+    const project = projectRows[0];
+    if (!project || project.visibility !== 'public') {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Project not available' });
+    }
+
+    const existing = await client.query(
+      `SELECT 1 FROM ${tableName} WHERE project_id=$1 AND user_id=$2`,
+      [projectId, currentUserId]
+    );
+
+    if (existing.rowCount > 0) {
+      await client.query(
+        `DELETE FROM ${tableName} WHERE project_id=$1 AND user_id=$2`,
+        [projectId, currentUserId]
+      );
+    } else {
+      await client.query(
+        `INSERT INTO ${tableName}(project_id, user_id) VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [projectId, currentUserId]
+      );
+    }
+
+    const { rows: countsRows } = await client.query(
+      `UPDATE projects
+          SET ${countColumn} = (SELECT COUNT(*) FROM ${tableName} WHERE project_id=$1),
+              updated_at = NOW()
+        WHERE id=$1
+        RETURNING likes_count, favorites_count`,
+      [projectId]
+    );
+
+    const counts = countsRows[0] || { likes_count: 0, favorites_count: 0 };
+
+    const { rowCount: likedCount } = await client.query(
+      'SELECT 1 FROM project_likes WHERE project_id=$1 AND user_id=$2',
+      [projectId, currentUserId]
+    );
+    const { rowCount: favoritedCount } = await client.query(
+      'SELECT 1 FROM project_favorites WHERE project_id=$1 AND user_id=$2',
+      [projectId, currentUserId]
+    );
+
+    await client.query('COMMIT');
+
+    return res.json({
+      project: {
+        id: projectId,
+        likes: Number(counts.likes_count) || 0,
+        favorites: Number(counts.favorites_count) || 0,
+        liked: likedCount > 0,
+        favorited: favoritedCount > 0
+      }
+    });
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackErr) {
+      console.error('Failed to rollback reaction transaction', rollbackErr);
+    }
+    console.error('Failed to toggle project reaction', err);
+    return res.status(500).json({ error: 'Failed to update project' });
+  } finally {
+    client.release();
   }
 }
 
@@ -1130,6 +1242,16 @@ app.get('/api/public-projects', async (req, res) => {
       whereClause += ` AND p.name ILIKE $${params.length}`;
     }
 
+    const currentUserId = req.session?.userId || (req.user && req.user.id);
+    let reactionSelect = '';
+    if (currentUserId) {
+      params.push(currentUserId);
+      const userParamIndex = params.length;
+      reactionSelect = `,
+              EXISTS(SELECT 1 FROM project_likes pl WHERE pl.project_id = p.id AND pl.user_id = $${userParamIndex}) AS liked_by_user,
+              EXISTS(SELECT 1 FROM project_favorites pf WHERE pf.project_id = p.id AND pf.user_id = $${userParamIndex}) AS favorited_by_user`;
+    }
+
     let orderClause = 'ORDER BY p.updated_at DESC, p.likes_count DESC';
     if (filter === 'trending') {
       orderClause = 'ORDER BY (p.likes_count + p.favorites_count) DESC, p.updated_at DESC';
@@ -1141,7 +1263,7 @@ app.get('/api/public-projects', async (req, res) => {
 
     const { rows } = await pool.query(
       `SELECT p.id, p.slug, p.name, p.likes_count, p.favorites_count, p.updated_at, p.owner_id,
-              COALESCE(NULLIF(u.nickname, ''), 'Player ' || p.owner_id::text) AS owner_name
+              COALESCE(NULLIF(u.nickname, ''), 'Player ' || p.owner_id::text) AS owner_name${reactionSelect}
          FROM projects p
          LEFT JOIN users u ON u.id = p.owner_id
          ${whereClause}
@@ -1158,17 +1280,20 @@ app.get('/api/public-projects', async (req, res) => {
       favorites: Number(row.favorites_count) || 0,
       ownerId: row.owner_id,
       ownerName: row.owner_name,
-      updatedAt: row.updated_at
+      updatedAt: row.updated_at,
+      liked: Boolean(row.liked_by_user),
+      favorited: Boolean(row.favorited_by_user)
     }));
 
-    const currentUserId = req.session?.userId || (req.user && req.user.id);
     let userProjects = [];
     if (currentUserId) {
       const { rows: userRows } = await pool.query(
-        `SELECT id, slug, name, likes_count, favorites_count, updated_at
-           FROM projects
-           WHERE owner_id=$1 AND visibility='public'
-           ORDER BY updated_at DESC
+        `SELECT p.id, p.slug, p.name, p.owner_id, p.likes_count, p.favorites_count, p.updated_at,
+                EXISTS(SELECT 1 FROM project_likes pl WHERE pl.project_id = p.id AND pl.user_id = $1) AS liked_by_user,
+                EXISTS(SELECT 1 FROM project_favorites pf WHERE pf.project_id = p.id AND pf.user_id = $1) AS favorited_by_user
+           FROM projects p
+           WHERE p.owner_id=$1 AND p.visibility='public'
+           ORDER BY p.updated_at DESC
            LIMIT 50`,
         [currentUserId]
       );
@@ -1176,13 +1301,23 @@ app.get('/api/public-projects', async (req, res) => {
         id: row.id,
         slug: row.slug,
         name: row.name,
+        ownerId: row.owner_id,
         likes: Number(row.likes_count) || 0,
         favorites: Number(row.favorites_count) || 0,
-        updatedAt: row.updated_at
+        updatedAt: row.updated_at,
+        liked: Boolean(row.liked_by_user),
+        favorited: Boolean(row.favorited_by_user)
       }));
     }
 
-    res.json({ projects, userProjects, filter, search, authenticated: !!currentUserId });
+    res.json({
+      projects,
+      userProjects,
+      filter,
+      search,
+      authenticated: !!currentUserId,
+      currentUserId: currentUserId ? Number(currentUserId) : null
+    });
   } catch (err) {
     console.error('Failed to fetch public projects', err);
     res.status(500).json({ error: 'Failed to fetch projects' });
@@ -1196,21 +1331,30 @@ app.get('/api/public-projects/:projectId', async (req, res) => {
   }
 
   try {
+    const params = [projectId];
+    const currentUserId = req.session?.userId || (req.user && req.user.id);
+    let reactionSelect = '';
+    if (currentUserId) {
+      params.push(currentUserId);
+      const userParamIndex = params.length;
+      reactionSelect = `,
+              EXISTS(SELECT 1 FROM project_likes pl WHERE pl.project_id = p.id AND pl.user_id = $${userParamIndex}) AS liked_by_user,
+              EXISTS(SELECT 1 FROM project_favorites pf WHERE pf.project_id = p.id AND pf.user_id = $${userParamIndex}) AS favorited_by_user`;
+    }
+
     const { rows } = await pool.query(
       `SELECT p.id, p.slug, p.name, p.likes_count, p.favorites_count, p.owner_id, p.visibility,
-              COALESCE(NULLIF(u.nickname, ''), 'Player ' || p.owner_id::text) AS owner_name
+              COALESCE(NULLIF(u.nickname, ''), 'Player ' || p.owner_id::text) AS owner_name${reactionSelect}
          FROM projects p
          LEFT JOIN users u ON u.id = p.owner_id
         WHERE p.id = $1`,
-      [projectId]
+      params
     );
 
     const project = rows[0];
     if (!project || project.visibility !== 'public') {
       return res.status(404).json({ error: 'Project not found' });
     }
-
-    const currentUserId = req.session?.userId || (req.user && req.user.id);
 
     res.json({
       project: {
@@ -1220,7 +1364,9 @@ app.get('/api/public-projects/:projectId', async (req, res) => {
         likes: Number(project.likes_count) || 0,
         favorites: Number(project.favorites_count) || 0,
         ownerId: project.owner_id,
-        ownerName: project.owner_name
+        ownerName: project.owner_name,
+        liked: Boolean(project.liked_by_user),
+        favorited: Boolean(project.favorited_by_user)
       },
       authenticated: !!currentUserId,
       isOwner: currentUserId ? Number(currentUserId) === Number(project.owner_id) : false
@@ -1300,6 +1446,14 @@ app.post('/api/public-projects/:projectId/copy', ensureAuth, ensureProjectContex
     res.status(500).json({ error: 'Failed to copy project' });
   }
 });
+
+app.post('/api/public-projects/:projectId/like', ensureAuth, (req, res) =>
+  handleProjectReaction(req, res, 'project_likes', 'likes_count')
+);
+
+app.post('/api/public-projects/:projectId/favorite', ensureAuth, (req, res) =>
+  handleProjectReaction(req, res, 'project_favorites', 'favorites_count')
+);
 
 app.get('/public-preview/:projectId', async (req, res) => {
   const projectId = Number.parseInt(req.params.projectId, 10);


### PR DESCRIPTION
## Summary
- add persistent tables and API handlers so public projects can be liked or favorited
- refresh the projects and project detail pages with CSRF support, reaction buttons, and clearer state handling
- return a friendly message when a public preview lacks an index file and ensure copying uses CSRF tokens

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_69045f1ec3208331a73ee1e45e5c7c67