### PR TITLE
Fix public project visibility checks and add project deletion

### DIFF
--- a/public/project-detail.html
+++ b/public/project-detail.html
@@ -423,6 +423,7 @@
         if (res.status === 404) {
           panel.hidden = true;
           notFound.hidden = false;
+          notFound.textContent = 'Project not found or is no longer public.';
           return;
         }
         if (!res.ok) {
@@ -447,22 +448,22 @@
           copyBtn.disabled = true;
           setReactionButtonsDisabled(true);
           showStatus('Sign in to copy, like, or favorite this project.');
-        } else if (data.isOwner) {
-          allowReactions = false;
-          copyBtn.disabled = true;
-          setReactionButtonsDisabled(true);
-          showStatus('This is your project. You can edit it directly in the editor.');
         } else {
           allowReactions = true;
-          copyBtn.disabled = false;
           setReactionButtonsDisabled(false);
-          showStatus('');
+          copyBtn.disabled = !!data.isOwner;
+          if (data.isOwner) {
+            showStatus('This is your project. You can edit it in the editor and react to it here.');
+          } else {
+            showStatus('');
+          }
           fetchCsrf().catch(() => {});
         }
       } catch (err) {
+        console.error('Failed to load project detail', err);
         panel.hidden = true;
         notFound.hidden = false;
-        showStatus('Could not load this project right now.', 'error');
+        notFound.textContent = 'Could not load this project right now. Please try again later.';
       }
     }
 

--- a/public/web.html
+++ b/public/web.html
@@ -487,6 +487,7 @@ body.perf .preview-container{
 
 .confirmation-popup{ text-align: center; }
 .confirmation-popup button{ margin-top: 14px; }
+.confirmation-popup p{ margin: 10px 0 0; color: var(--muted); line-height: 1.5; }
 
 #project-settings{
   margin-top: 18px;
@@ -495,6 +496,37 @@ body.perf .preview-container{
   display: none;
   flex-direction: column;
   gap: 12px;
+}
+
+#project-settings .danger-zone{
+  margin-top: 6px;
+  padding-top: 12px;
+  border-top: 1px dashed rgba(252,165,165,0.35);
+  display: flex;
+  justify-content: flex-end;
+}
+
+#project-settings .danger-zone button{
+  background: rgba(239,68,68,0.18);
+  border: 1px solid rgba(239,68,68,0.45);
+  color: #fca5a5;
+  padding: 8px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), transform var(--transition);
+}
+
+#project-settings .danger-zone button:hover:not(:disabled){
+  transform: translateY(-1px);
+  background: rgba(239,68,68,0.32);
+  border-color: rgba(239,68,68,0.65);
+}
+
+#project-settings .danger-zone button:disabled{
+  opacity: .6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .visibility-toggle{
@@ -851,6 +883,9 @@ body.perf .preview-container{
               <button type="button" data-project-visibility="public">Public</button>
           </div>
       </label>
+      <div class="danger-zone">
+          <button type="button" id="delete-project-btn">Delete Project</button>
+      </div>
   </div>
 </div>
   
@@ -872,6 +907,14 @@ body.perf .preview-container{
     <button id="confirm-btn">Yes</button>
     <button id="cancel-btn">No</button>
     <button class="close-btn" id="close-confirmation-btn">X</button>
+</div>
+
+<div id="delete-project-popup" class="confirmation-popup">
+    <h3>Are you sure you want to delete your project?</h3>
+    <p id="delete-project-message">This action cannot be undone.</p>
+    <button id="delete-project-confirm">Yes</button>
+    <button id="delete-project-cancel">No</button>
+    <button class="close-btn" id="close-delete-project-btn">X</button>
 </div>
 
 <!-- unsupported file type popup -->
@@ -1039,6 +1082,12 @@ const newProjectVisibilityButtons = document.querySelectorAll('[data-new-visibil
 const projectSettingsSection = document.getElementById('project-settings');
 const projectNameInput = document.getElementById('project-name-input');
 const projectVisibilityButtons = document.querySelectorAll('[data-project-visibility]');
+const deleteProjectBtn = document.getElementById('delete-project-btn');
+const deleteProjectPopup = document.getElementById('delete-project-popup');
+const deleteProjectMessage = document.getElementById('delete-project-message');
+const deleteProjectConfirmBtn = document.getElementById('delete-project-confirm');
+const deleteProjectCancelBtn = document.getElementById('delete-project-cancel');
+const closeDeleteProjectBtn = document.getElementById('close-delete-project-btn');
 const projectOptions = JSON.parse(localStorage.getItem('projectOptions') || '{}');
 
 popoutBtn.onclick = async () => {
@@ -1206,9 +1255,11 @@ function updateProjectSettingsUI() {
   const activeProject = getActiveProjectInfo();
   if (!activeProject) {
     projectSettingsSection.style.display = 'none';
+    if (deleteProjectBtn) deleteProjectBtn.disabled = true;
     return;
   }
   projectSettingsSection.style.display = 'flex';
+  if (deleteProjectBtn) deleteProjectBtn.disabled = false;
   if (projectNameInput && document.activeElement !== projectNameInput) {
     projectNameInput.value = activeProject.name || '';
   }
@@ -1334,6 +1385,35 @@ async function updateActiveProject(details) {
   }
 }
 
+async function deleteActiveProject() {
+  const active = getActiveProjectInfo();
+  if (!active) return;
+  const deletedName = active.name || 'Untitled Project';
+  if (deleteProjectConfirmBtn) deleteProjectConfirmBtn.disabled = true;
+  try {
+    const res = await postJSON('/api/projects/delete', { id: active.id });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.error || 'Failed to delete project');
+    }
+    projectState.list = Array.isArray(data.projects)
+      ? data.projects
+      : (projectState.list || []).filter(p => p && p.id !== active.id);
+    projectState.active = data.active || 'draft';
+    closeModal(deleteProjectPopup);
+    renderProjectDropdown();
+    updateProjectSettingsUI();
+    resetProjectFileState();
+    await loadGeneratedFiles();
+    log(`Deleted project "${deletedName}"`, 'info');
+  } catch (err) {
+    console.error(err);
+    log(err.message || 'Failed to delete project', 'error');
+  } finally {
+    if (deleteProjectConfirmBtn) deleteProjectConfirmBtn.disabled = false;
+  }
+}
+
 function openNewProjectModal() {
   if (!newProjectPopup) return;
   if (newProjectNameInput) {
@@ -1424,6 +1504,32 @@ projectVisibilityButtons.forEach(btn => {
     updateActiveProject({ visibility: value });
   });
 });
+
+if (deleteProjectBtn && deleteProjectPopup) {
+  deleteProjectBtn.addEventListener('click', () => {
+    const active = getActiveProjectInfo();
+    if (!active) return;
+    if (deleteProjectMessage) {
+      const name = active.name || 'Untitled Project';
+      const visibilityNote = active.visibility === 'public'
+        ? 'Deleting it will also remove it from the public projects page.'
+        : 'Deleting it will remove it from your workspace.';
+      deleteProjectMessage.textContent = `"${name}" will be permanently deleted. ${visibilityNote} This action cannot be undone.`;
+    }
+    openModal(deleteProjectPopup);
+  });
+}
+
+[deleteProjectCancelBtn, closeDeleteProjectBtn].forEach(btn => {
+  if (!btn) return;
+  btn.addEventListener('click', () => closeModal(deleteProjectPopup));
+});
+
+if (deleteProjectConfirmBtn) {
+  deleteProjectConfirmBtn.addEventListener('click', () => {
+    deleteActiveProject();
+  });
+}
 
 initializeWorkspace().catch(err => {
   console.error('Failed to initialize workspace', err);

--- a/server.js
+++ b/server.js
@@ -173,6 +173,10 @@ function getProjectRootByUserId(userId, projectId) {
   return path.join(base, PROJECTS_DIR, projectId);
 }
 
+function isProjectPublic(visibility) {
+  return typeof visibility === 'string' && visibility.trim().toLowerCase() === 'public';
+}
+
 function loadProjectList(req) {
   ensureDirs(req);
   const metaPath = path.join(getUserBasePath(req), PROJECT_META);
@@ -186,7 +190,7 @@ function loadProjectList(req) {
       .map(p => ({
         id: p.id,
         name: typeof p.name === 'string' && p.name.trim() ? p.name.trim() : 'Untitled Project',
-        visibility: p.visibility === 'public' ? 'public' : 'private'
+        visibility: isProjectPublic(p.visibility) ? 'public' : 'private'
       }));
   } catch (err) {
     console.error('Failed to read project metadata', err);
@@ -311,7 +315,7 @@ async function handleProjectReaction(req, res, tableName, countColumn) {
       [projectId]
     );
     const project = projectRows[0];
-    if (!project || project.visibility !== 'public') {
+    if (!project || !isProjectPublic(project.visibility)) {
       await client.query('ROLLBACK');
       return res.status(404).json({ error: 'Project not available' });
     }
@@ -1228,6 +1232,73 @@ app.post('/api/projects/update', ensureAuth, ensureProjectContext, async (req, r
   }
 });
 
+app.post('/api/projects/delete', ensureAuth, ensureProjectContext, async (req, res) => {
+  try {
+    const { id } = req.body || {};
+    if (!id || typeof id !== 'string' || id === 'draft') {
+      return res.status(400).json({ error: 'Invalid project id' });
+    }
+
+    const projects = req.projectList || loadProjectList(req);
+    const idx = projects.findIndex(p => p.id === id);
+    if (idx === -1) {
+      return res.status(404).json({ error: 'Project not found' });
+    }
+
+    projects.splice(idx, 1);
+    saveProjectList(req, projects);
+    req.projectList = projects;
+
+    const userId = req.session?.userId || (req.user && req.user.id);
+    if (userId) {
+      try {
+        await pool.query('DELETE FROM projects WHERE owner_id=$1 AND slug=$2', [userId, id]);
+      } catch (err) {
+        console.error('Failed to delete project from database', err);
+      }
+    }
+
+    try {
+      const projectDir = path.join(getUserBasePath(req), PROJECTS_DIR, id);
+      if (fs.existsSync(projectDir)) {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    } catch (err) {
+      console.error('Failed to delete project files', err);
+    }
+
+    let nextActive = req.currentProjectId || 'draft';
+    if (nextActive === id) {
+      nextActive = 'draft';
+    }
+    if (req.session) {
+      if (req.session.selectedProject === id) {
+        req.session.selectedProject = 'draft';
+      } else if (req.session.selectedProject && req.session.selectedProject !== 'draft') {
+        nextActive = req.session.selectedProject;
+      }
+    }
+    if (nextActive !== 'draft' && !projects.some(p => p.id === nextActive)) {
+      nextActive = 'draft';
+      if (req.session) {
+        req.session.selectedProject = 'draft';
+      }
+    }
+
+    if (req.session) {
+      req.session.selectedProject = nextActive;
+    }
+
+    req.currentProjectId = nextActive;
+    ensureProjectRoot(req, nextActive);
+
+    res.json({ projects, active: nextActive });
+  } catch (err) {
+    console.error('Failed to delete project', err);
+    res.status(500).json({ error: 'Failed to delete project' });
+  }
+});
+
 app.get('/api/public-projects', async (req, res) => {
   try {
     const search = typeof req.query.search === 'string' ? req.query.search.trim() : '';
@@ -1236,7 +1307,7 @@ app.get('/api/public-projects', async (req, res) => {
     const filter = allowedFilters.has(filterParam) ? filterParam : 'relevance';
 
     const params = [];
-    let whereClause = `WHERE p.visibility = 'public'`;
+    let whereClause = `WHERE TRIM(LOWER(p.visibility)) = 'public'`;
     if (search) {
       params.push(`%${search}%`);
       whereClause += ` AND p.name ILIKE $${params.length}`;
@@ -1292,7 +1363,7 @@ app.get('/api/public-projects', async (req, res) => {
                 EXISTS(SELECT 1 FROM project_likes pl WHERE pl.project_id = p.id AND pl.user_id = $1) AS liked_by_user,
                 EXISTS(SELECT 1 FROM project_favorites pf WHERE pf.project_id = p.id AND pf.user_id = $1) AS favorited_by_user
            FROM projects p
-           WHERE p.owner_id=$1 AND p.visibility='public'
+           WHERE p.owner_id=$1 AND TRIM(LOWER(p.visibility))='public'
            ORDER BY p.updated_at DESC
            LIMIT 50`,
         [currentUserId]
@@ -1352,7 +1423,7 @@ app.get('/api/public-projects/:projectId', async (req, res) => {
     );
 
     const project = rows[0];
-    if (!project || project.visibility !== 'public') {
+    if (!project || !isProjectPublic(project.visibility)) {
       return res.status(404).json({ error: 'Project not found' });
     }
 
@@ -1396,7 +1467,7 @@ app.post('/api/public-projects/:projectId/copy', ensureAuth, ensureProjectContex
       [projectId]
     );
     const project = rows[0];
-    if (!project || project.visibility !== 'public') {
+    if (!project || !isProjectPublic(project.visibility)) {
       return res.status(404).json({ error: 'Project not available' });
     }
 
@@ -1467,7 +1538,7 @@ app.get('/public-preview/:projectId', async (req, res) => {
       [projectId]
     );
     const project = rows[0];
-    if (!project || project.visibility !== 'public') {
+    if (!project || !isProjectPublic(project.visibility)) {
       return res.status(404).end();
     }
 
@@ -1491,7 +1562,7 @@ app.get('/public-preview/:projectId/*', async (req, res) => {
       [projectId]
     );
     const project = rows[0];
-    if (!project || project.visibility !== 'public') {
+    if (!project || !isProjectPublic(project.visibility)) {
       return res.status(404).end();
     }
 


### PR DESCRIPTION
## Summary
- ensure public project visibility checks handle casing/whitespace and add an authenticated project deletion API
- update the editor settings UI with a delete button and confirmation flow that removes files and database records
- allow project owners to react to their projects in the detail view and show accurate load errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69080779a6d0833191f85584c1a8399f